### PR TITLE
feat: add conference name and date on center deck

### DIFF
--- a/presentation.js
+++ b/presentation.js
@@ -87,7 +87,8 @@ class Presentation {
         line1: `[ ${this.currentSlide + 1} / ${this.slides.length} ]`
       },
       center: {
-        line1: "Red Hat OpenShift"
+        line1: this.meta.conference,
+        line2: this.meta.date
       }
     });
     this.renderCurrentSlide();


### PR DESCRIPTION
Removes the `Red Hat OpenShift` name from the bottom deck and adds conference name and date in the centre of the deck

![Screenshot 2019-12-11 at 13 28 42](https://user-images.githubusercontent.com/18121502/70602376-53454f00-1c1a-11ea-8cf2-be443669d7cc.png)
