### PR TITLE
fix(json-schema): fixed missing closing quote

### DIFF
--- a/assets/json-schema.json
+++ b/assets/json-schema.json
@@ -240,7 +240,7 @@
         "text": {
           "type": "string",
           "default": "",
-          "description": "Some text to be displayed. Text will be centered and wraps automatically. Supports multiple lines with a newline escape (\n).
+          "description": "Some text to be displayed. Text will be centered and wraps automatically. Supports multiple lines with a newline escape (\n)."
         }
       },
       "required": ["title", "text"]


### PR DESCRIPTION
Well that's awkward... a quote was missing causing the simple slide verification to fail. Only found out just now when I added one to my own slidedeck and I got an error because I was missing "title" in the config.